### PR TITLE
set NJBOS=1 due to suspected build parallelization problems

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,4 +1,5 @@
 # EupsPkg config file. Sourced by 'eupspkg'
 
+NJOBS=1
 MAKE_BUILD_TARGETS="all shared"
 CONFIGURE_OPTIONS="--prefix=$PREFIX --libdir=$PREFIX/lib"


### PR DESCRIPTION
Inexplicable build failures have been observed number of times.  It is
suspected that this may be due to a make parallelization problem.
